### PR TITLE
Proper bans and codestyles

### DIFF
--- a/adminbot.py
+++ b/adminbot.py
@@ -1,6 +1,7 @@
 import os
 import asyncio
 from pathlib import Path
+from functools import wraps
 import logging
 
 from telegram import Update, Message
@@ -68,6 +69,7 @@ logging.basicConfig(
 db: Database
 
 def admin_check(action):
+    @wraps(action)
     async def wrapper(update: Update, 
                       context: ContextTypes.DEFAULT_TYPE, 
                       *args, **kwargs):

--- a/adminbot.py
+++ b/adminbot.py
@@ -186,6 +186,7 @@ async def clear_download_cache(update: Update, context: ContextTypes.DEFAULT_TYP
         await context.bot.send_message(chat_id, m)
         await asyncio.sleep(1)
 
+@admin_check
 async def ban_chats(update: Update, context: ContextTypes.DEFAULT_TYPE):
     chat_id = update.effective_chat.id
     try:

--- a/config.py
+++ b/config.py
@@ -11,6 +11,7 @@ ADMIN_BOT_TOKEN = os.environ.get("ADMIN_BOT_TOKEN")
 
 DB_CONFIG = {
     'host': '127.0.0.1',
+    'port': 3306,
     'user': os.environ.get('DB_USER'),
     'password': os.environ.get('DB_PASS'),
     'database': 'divination'

--- a/config.py
+++ b/config.py
@@ -1,4 +1,6 @@
 import os
+from datetime import timedelta
+
 from dotenv import load_dotenv
 # load environment variables from ".env" file
 load_dotenv()
@@ -15,3 +17,7 @@ DB_CONFIG = {
 }
 
 DOWNLOAD_DIR = "downloaded_books"
+
+# Time between updates of banned users list from database
+#  Note: updates are lazy evaluated (when it needs to check user for ban)    
+BANLIST_UPD_INTERVAL = timedelta(minutes=2)

--- a/config.py
+++ b/config.py
@@ -1,4 +1,7 @@
 import os
+from dotenv import load_dotenv
+# load environment variables from ".env" file
+load_dotenv()
 
 BOT_TOKEN = os.environ.get("BOT_TOKEN")
 

--- a/database.py
+++ b/database.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Callable, Optional, Sequence
 from itertools import count
+from functools import wraps
 import datetime
 
 import mysql.connector
@@ -11,6 +12,7 @@ from bookparse import Book
 
 # MySQL Errors handling. Used as decorator
 def handle_mysql_errors(func: Callable):
+    @wraps(func)
     def wrapper(db_obj, *args, **kwargs):
         try:
             return func(db_obj, *args, **kwargs)

--- a/db_setup.py
+++ b/db_setup.py
@@ -53,7 +53,7 @@ def insert_admin(connection):
                 logging.info(f"admin insertion: {alias}")
                 curs.execute(statement.format(admin_id))
     else:
-        logging.info("skiping admin insertion")
+        logging.info("skipping admin insertion")
 
 
 if __name__ == '__main__':

--- a/fonts/_your_fonts_here_.md
+++ b/fonts/_your_fonts_here_.md
@@ -1,3 +1,4 @@
 Dowload these fonts files:
-    `Ubuntu-Bold.ttf`
+    `Ubuntu-Bold.ttf` — Ubuntu Font, Bold 
+    `georgiai.ttf` — Georgia, Italic
 and place it in this directory

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mysql-connector-python
 nltk
 pytest
 Pillow
+python-dotenv

--- a/runbot.py
+++ b/runbot.py
@@ -1,6 +1,7 @@
 import logging
 import io
 import asyncio
+from functools import wraps 
 from typing import Callable, Set
 
 from telegram import Update
@@ -75,6 +76,7 @@ logging.basicConfig(
 )
 
 def check_banned(func: Callable) -> Callable:
+    @wraps(func)
     async def wrapper(update: Update,
                       context: ContextTypes.DEFAULT_TYPE,
                       *args, **kwargs):


### PR DESCRIPTION
- Fix security issue that allowed every user who have an access to Admin's bot ban any user (if it's chat id belongs to the list of bot users)
- Add `/unban` command for Admin's bot 
- Use python-dotenv to load environmental variables
- Update list of banned users lazy, only when the check is being performed
- Use `functools.wraps` for decorators (it allows to save `__name__`, `__docs__` and other useful attributes of the base function).
- Add docstring to some functions and rephrase the old ones. 